### PR TITLE
Fix typo event listener

### DIFF
--- a/examples/stream.rs
+++ b/examples/stream.rs
@@ -1,18 +1,16 @@
-use clipboard_stream::{Body, ClipboadEventListener, Kind};
+use clipboard_stream::{Body, ClipboardEventListener, Kind};
 use futures::StreamExt;
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() {
-    let mut event_listener = ClipboadEventListener::spawn();
+    let mut event_listener = ClipboardEventListener::spawn();
     let mut stream = event_listener.new_stream(Kind::Utf8String, 32).unwrap();
 
     while let Some(content) = stream.next().await {
         match content {
-            Ok(v) => {
-                match v {
-                    Body::Utf8String(v) => println!("got string: {}", v),
-                }
-            }
+            Ok(v) => match v {
+                Body::Utf8String(v) => println!("got string: {}", v),
+            },
             Err(e) => eprintln!("{}", e),
         }
     }

--- a/examples/try_stream.rs
+++ b/examples/try_stream.rs
@@ -1,8 +1,8 @@
-use clipboard_stream::{ClipboadEventListener, Kind};
+use clipboard_stream::{ClipboardEventListener, Kind};
 use futures::stream::TryStreamExt;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut event_lisener = ClipboadEventListener::spawn();
+    let mut event_lisener = ClipboardEventListener::spawn();
     let mut stream = event_lisener.new_stream(Kind::Utf8String, 32)?;
 
     let future = async move {

--- a/src/event_listener.rs
+++ b/src/event_listener.rs
@@ -11,18 +11,18 @@ use crate::{
 /// Clipboard event change listener.
 ///
 /// Listen for clipboard change events and notifies [`ClipboardStream`].
-pub struct ClipboadEventListener {
+pub struct ClipboardEventListener {
     driver: Option<Driver>,
     body_senders: Arc<Mutex<BodySenders>>,
 }
 
-impl ClipboadEventListener {
-    /// Creates a new [`ClipboadEventListener`] that monitors clipboard changes in a dedicated OS thread.
+impl ClipboardEventListener {
+    /// Creates a new [`ClipboardEventListener`] that monitors clipboard changes in a dedicated OS thread.
     pub fn spawn() -> Self {
         let body_senders = Arc::new(Mutex::new(BodySenders::new()));
 
         let driver = Driver::new(body_senders.clone());
-        ClipboadEventListener {
+        ClipboardEventListener {
             driver: Some(driver),
             body_senders,
         }
@@ -37,10 +37,10 @@ impl ClipboadEventListener {
     ///
     /// # Example
     /// ```
-    /// # use clipboard_stream::{Kind, ClipboadEventListener, ClipboardStream};
+    /// # use clipboard_stream::{Kind, ClipboardEventListener, ClipboardStream};
     /// # #[tokio::main]
     /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    ///     let mut event_listener = ClipboadEventListener::spawn();
+    ///     let mut event_listener = ClipboardEventListener::spawn();
     ///
     ///     let buf_size = 32;
     ///     let stream = event_listener.new_stream(Kind::Utf8String, buf_size)?;
@@ -62,13 +62,13 @@ impl ClipboadEventListener {
     }
 }
 
-impl Default for ClipboadEventListener {
+impl Default for ClipboardEventListener {
     fn default() -> Self {
-        ClipboadEventListener::spawn()
+        ClipboardEventListener::spawn()
     }
 }
 
-impl Drop for ClipboadEventListener {
+impl Drop for ClipboardEventListener {
     fn drop(&mut self) {
         drop(self.driver.take())
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,7 +46,7 @@ mod sys;
 
 pub use crate::body::{Body, Kind};
 pub use crate::error::Error;
-pub use crate::event_listener::ClipboadEventListener;
+pub use crate::event_listener::ClipboardEventListener;
 pub use crate::stream::ClipboardStream;
 
 pub(crate) type Msg = Result<Body, crate::error::Error>;


### PR DESCRIPTION
`ClipboadEventListener` is typo. We changed to `ClipboardEventListener`.  