### PR TITLE
refactor: remove ClipboardSys trait

### DIFF
--- a/src/driver.rs
+++ b/src/driver.rs
@@ -10,7 +10,7 @@ use std::{
 use crate::{
     Kind,
     body::{Body, BodySenders},
-    sys::{ClipBoardSys, OSXSys},
+    sys::OSXSys,
 };
 
 /// An event driver that monitors clipboard updates and notify

--- a/src/sys.rs
+++ b/src/sys.rs
@@ -3,24 +3,18 @@ use objc2_app_kit::{NSPasteboard, NSPasteboardTypeString};
 
 use crate::error::Error;
 
-/// system call wrapper to know event change and get item
-pub(crate) trait ClipBoardSys {
-    fn get_item(&mut self) -> Result<String, Error>;
-    fn get_change_count(&self) -> Result<i64, Error>;
-}
-
 #[cfg(target_os = "macos")]
 pub(crate) struct OSXSys;
 
 #[cfg(target_os = "macos")]
-impl ClipBoardSys for OSXSys {
-    fn get_change_count(&self) -> Result<i64, Error> {
+impl OSXSys {
+    pub(crate) fn get_change_count(&self) -> Result<i64, Error> {
         let inner = unsafe { NSPasteboard::generalPasteboard() };
         let count = unsafe { inner.changeCount() };
         Ok(count as i64)
     }
 
-    fn get_item(&mut self) -> Result<String, Error> {
+    pub(crate) fn get_item(&mut self) -> Result<String, Error> {
         let item = unsafe {
             let inner = NSPasteboard::generalPasteboard();
             inner.dataForType(NSPasteboardTypeString)


### PR DESCRIPTION
## OverView
The way to know clipboard change event is defference with OS.
It's difficult to abstract. So the strategy is changed to define each OS sys and use cfg(target_os) in driver
## Changes
- Remove `ClipboardSys` trait
- The implementation of get change count and itme is moved to OSXSys directory
## Future
Introduce `Notify` trait in `driver` module. Driver
```rust
trait Notify {
  fn notify(&self, body_senders: Arc<Mutex<BodySenders>>);
}

impl Driver {
  pub fn new(body_senders: Arc<Mutex<BodySenders>>) -> Self {
    #[cfg(target_os = "macos")]
    let notify = OSXNotifier;
    #[cfg(target_os = "windows")]
    let notify = WindowsNotifier;

    let handle = std::thread::spawn(move || {
      motify.notify(body_senders)
    });

    // ...
  }
}
```

