### PR TITLE
refactor: change Sys to be stored in another structure to reduce the number of system calls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -58,6 +58,7 @@ name = "clipboard-stream"
 version = "0.2.0"
 dependencies = [
  "futures",
+ "objc2",
  "objc2-app-kit",
  "thiserror",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ targets = ["aarch64-apple-darwin", "x86_64-apple-darwin"]
 
 [dependencies]
 futures = "0.3"
+objc2 = "0.6.2"
 objc2-app-kit = "0.3"
 thiserror = "2"
 

--- a/src/driver.rs
+++ b/src/driver.rs
@@ -27,12 +27,17 @@ impl Driver {
 
         #[cfg(target_os = "macos")]
         let stop_cl = stop.clone();
-        #[cfg(target_os = "macos")]
-        let observer = OSXObserver::new(stop_cl);
 
         // spawn OS thread
         // observe clipboard change event and send item
         let handle = std::thread::spawn(move || {
+            // construct Observer in thread
+            // OSXSys is **not** implemented Send + Sync
+            // in order to send Observer, construct it
+            #[cfg(target_os = "macos")]
+            let observer = OSXObserver::new(stop_cl);
+
+            // event change observe loop
             observer.observe(body_senders);
         });
 


### PR DESCRIPTION
## Changes
- `OSXSys` have `Retained<NSPasteboard>` type in inner filed
- `OSXObserver` have `OSXSys` type in sys filed
- The location of calling `OSXOberver`'s construct method