### PR TITLE
refactor: change the return type of the OSXSys::get_change_count to isize

### DIFF
--- a/src/body.rs
+++ b/src/body.rs
@@ -77,6 +77,7 @@ impl BodySenders {
         Ok(())
     }
 
+    #[allow(dead_code)]
     /// Send a message to the sender if available.
     /// Errors are logged but do not stop other sends.
     pub(crate) fn send_all_if_some(&mut self, msg: Msg) {
@@ -92,6 +93,7 @@ fn try_send(tx: &mut Option<Sender<Msg>>, msg: Msg) -> Result<(), TrySendError<M
     Ok(())
 }
 
+#[allow(dead_code)]
 #[inline]
 fn send_ignore_err(tx: &mut Option<Sender<Msg>>, msg: Msg) {
     if let Some(v) = tx

--- a/src/driver/observer.rs
+++ b/src/driver/observer.rs
@@ -38,14 +38,7 @@ impl Observer for OSXObserver {
 
         while !self.stop.load(Ordering::Relaxed) {
             std::thread::sleep(time::Duration::from_millis(200));
-            let change_count = match self.sys.get_change_count() {
-                Ok(c) => c,
-                Err(_) => {
-                    let mut gurad = body_senders.lock().unwrap();
-                    gurad.send_all_if_some(Err(crate::error::Error::GetItem));
-                    continue;
-                }
-            };
+            let change_count = self.sys.get_change_count();
 
             if Some(change_count) == last_count {
                 continue;

--- a/src/sys.rs
+++ b/src/sys.rs
@@ -17,9 +17,9 @@ impl OSXSys {
         OSXSys { inner }
     }
 
-    pub(crate) fn get_change_count(&self) -> Result<i64, Error> {
+    pub(crate) fn get_change_count(&self) -> isize {
         let count = unsafe { self.inner.changeCount() };
-        Ok(count as i64)
+        count
     }
 
     pub(crate) fn get_item(&self) -> Result<String, Error> {

--- a/src/sys.rs
+++ b/src/sys.rs
@@ -18,8 +18,7 @@ impl OSXSys {
     }
 
     pub(crate) fn get_change_count(&self) -> isize {
-        let count = unsafe { self.inner.changeCount() };
-        count
+        unsafe { self.inner.changeCount() }
     }
 
     pub(crate) fn get_item(&self) -> Result<String, Error> {


### PR DESCRIPTION
## Changes
- OSXSys::get_change_count return type from `Result<i64, Error> to isize
- OSXObserver dose not send Error when call get_change_count
- add atribute to allow dead code

## Why change
The system call of inner OSXSys::get_change_count is never faile, so the error handling of it is waste and it makes us confused. 
