### PR TITLE
fix: fix forget to use StreamId

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,4 +51,4 @@ mod sys;
 pub use crate::body::{Body, Kind};
 pub use crate::error::Error;
 pub use crate::event_listener::ClipboardEventListener;
-pub use crate::stream::ClipboardStream;
+pub use crate::stream::{ClipboardStream, StreamId};

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -62,5 +62,6 @@ impl Drop for ClipboardStream {
     }
 }
 
+/// An Id to specify the [`ClipboardStream`].
 #[derive(Debug, Clone, Eq, Hash, PartialEq)]
 pub struct StreamId(pub(crate) usize);


### PR DESCRIPTION
## Issue 
close #25
## Overview
`StreamId` is public, but `body` module is private. So, we can't access `StreamId`.   
In addition, we added document to StreamId.