### PR TITLE
docs: remove unnecessary attributes

### DIFF
--- a/examples/stream.rs
+++ b/examples/stream.rs
@@ -14,7 +14,6 @@ async fn main() {
             Body::Utf8String(text) => {
                 println!("got string: {}", text);
             }
-            #[cfg(target_os = "macos")]
             Body::Image {
                 mime: mime_type,
                 data: v,


### PR DESCRIPTION
The difference of image type caused supported as a clipboard item was solved by introducing `MimeType`.  
So we don't have to add attribute `target_os`.  