### PR TITLE
chore: fix library doc comment

### DIFF
--- a/src/sys.rs
+++ b/src/sys.rs
@@ -1,4 +1,4 @@
-/// System call wrapper module
+//! System call wrapper module
 
 #[cfg(target_os = "macos")]
 use objc2::rc::Retained;


### PR DESCRIPTION
warning: empty line after doc comment
 --> src/sys.rs:1:1
  |
1 | / /// System call wrapper module
2 | |
  | |_^