### PR TITLE
refactor: allow ClipboardEventListener::spawn to specify buffer size

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,12 +3,12 @@ name = "clipboard-stream"
 version = "0.2.1"
 edition = "2024"
 readme = "README.md"
-repository = "https://github.com/nakaryo716/clipboard-stream" 
-license = "MIT" 
+repository = "https://github.com/nakaryo716/clipboard-stream"
+license = "MIT"
 description = """
 Async stream of clipboard change events
 """
-documentation = "https://docs.rs/clipboard-stream" 
+documentation = "https://docs.rs/clipboard-stream"
 keywords = ["clipboard"]
 
 [package.metadata.docs.rs]

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ use std::sync::{
 
 #[tokio::main]
 async fn main() {
-    let event_listener = ClipboardEventListener::spawn();
+    let event_listener = ClipboardEventListener::spawn(32);
     let mut stream = event_listener.new_stream();
     let count = Arc::new(AtomicU32::new(0));
 

--- a/examples/stream.rs
+++ b/examples/stream.rs
@@ -9,7 +9,7 @@ use std::sync::{
 
 #[tokio::main]
 async fn main() {
-    let event_listener = ClipboardEventListener::spawn();
+    let event_listener = ClipboardEventListener::spawn(32);
     let mut stream = event_listener.new_stream();
     let count = Arc::new(AtomicU32::new(0));
 

--- a/src/event_listener.rs
+++ b/src/event_listener.rs
@@ -12,8 +12,11 @@ pub struct ClipboardEventListener {
 
 impl ClipboardEventListener {
     /// Creates a new [`ClipboardEventListener`] that monitors clipboard changes in a dedicated OS thread.
-    pub fn spawn() -> Self {
-        let (tx, rx) = mpsc::channel(32);
+    ///
+    /// Clipboard Item is  bounded, this EventListener provides backpressure.
+    /// `buffer` specify this size.
+    pub fn spawn(buffer: usize) -> Self {
+        let (tx, rx) = mpsc::channel(buffer);
 
         ClipboardEventListener {
             driver: Driver::new(tx),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,7 @@
 //!
 //! #[tokio::main]
 //! async fn main() {
-//!     let event_listener = ClipboardEventListener::spawn();
+//!     let event_listener = ClipboardEventListener::spawn(32);
 //!     let mut stream = event_listener.new_stream();
 //!     let count = Arc::new(AtomicU32::new(0));
 //!


### PR DESCRIPTION
## Motivation
ClipboardEventListener::spawn internaly create channel with 32 buffer size. So, this is uncontrollable.  
This PR allow user to controll buffer size.  