### PR TITLE
refactor: OSXSys::get_body return type is changed

### DIFF
--- a/src/driver/observer.rs
+++ b/src/driver/observer.rs
@@ -43,11 +43,11 @@ impl Observer for OSXObserver {
             }
             last_count = change_count;
 
-            self.sys.get_bodies().into_iter().for_each(|body| {
-                if let Err(e) = tx.try_send(body) {
-                    eprintln!("{}", e);
-                }
-            });
+            if let Some(body) = self.sys.get_body()
+                && let Err(e) = tx.try_send(body)
+            {
+                eprintln!("{}", e);
+            }
         }
     }
 }

--- a/src/sys.rs
+++ b/src/sys.rs
@@ -23,10 +23,7 @@ impl OSXSys {
         unsafe { self.inner.changeCount() }
     }
 
-    pub(crate) fn get_bodies(&self) -> Vec<Body> {
-        // the reason of capacity size is number of kind 'Body'
-        let mut bodies = Vec::with_capacity(1);
-
+    pub(crate) fn get_body(&self) -> Option<Body> {
         // get Utf8String body type
         let string_data = unsafe { self.inner.dataForType(NSPasteboardTypeString) };
 
@@ -35,18 +32,20 @@ impl OSXSys {
             let bytes = v.to_vec();
             // if String::from_utf8 is failed, we don't push.
             if let Ok(text) = String::from_utf8(bytes) {
-                bodies.push(Body::Utf8String(text));
+                return Some(Body::Utf8String(text));
             }
         }
 
         // get PNG image data
         let png_data = unsafe { self.inner.dataForType(NSPasteboardTypePNG) };
         if let Some(v) = png_data {
-            bodies.push(Body::Image {
+            return Some(Body::Image {
                 mime: MimeType::ImagePng,
                 data: v.to_vec(),
-            })
+            });
         }
-        bodies
+
+        // when unhandled data type copied, return None
+        None
     }
 }


### PR DESCRIPTION
## Motivation
Return type is changed from `Vec<Body>` to `Option<Body>`.  
The case clipboard body type will be String and PNG is never occured.  So, we don't have to use `Vec<T>`
To ignore unhandle body type, introduced `Option<T>`